### PR TITLE
Fix STAFact sample to keep tests on STA

### DIFF
--- a/STAExamples/STAExamples.csproj
+++ b/STAExamples/STAExamples.csproj
@@ -42,6 +42,7 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
+    <Reference Include="WindowsBase" />
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
     </Reference>

--- a/STAExamples/STATestCase.cs
+++ b/STAExamples/STATestCase.cs
@@ -4,6 +4,7 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Windows.Threading;
 using Xunit.Abstractions;
 using Xunit.Sdk;
 
@@ -40,9 +41,31 @@ namespace STAExamples
             {
                 try
                 {
-                    var testCaseTask = testCase.RunAsync(diagnosticMessageSink, messageBus, constructorArguments, aggregator,
-                        cancellationTokenSource);
-                    tcs.SetResult(testCaseTask.Result);
+                    // Set up the SynchronizationContext so that any awaits
+                    // resume on the STA thread as they would in a GUI app.
+                    SynchronizationContext.SetSynchronizationContext(new DispatcherSynchronizationContext());
+
+                    // Start off the test method.
+                    var testCaseTask = this.testCase.RunAsync(diagnosticMessageSink, messageBus, constructorArguments, aggregator, cancellationTokenSource);
+
+                    // Arrange to pump messages to execute any async work associated with the test.
+                    var frame = new DispatcherFrame();
+                    Task.Run(async delegate
+                    {
+                        try
+                        {
+                            await testCaseTask;
+                        }
+                        finally
+                        {
+                            // The test case's execution is done. Terminate the message pump.
+                            frame.Continue = false;
+                        }
+                    });
+                    Dispatcher.PushFrame(frame);
+
+                    // Report the result back to the Task we returned earlier.
+                    CopyTaskResultFrom(tcs, testCaseTask);
                 }
                 catch (Exception e)
                 {
@@ -98,6 +121,37 @@ namespace STAExamples
         public void Serialize(IXunitSerializationInfo info)
         {
             info.AddValue("InnerTestCase", testCase);
+        }
+
+        private static void CopyTaskResultFrom<T>(TaskCompletionSource<T> tcs, Task<T> template)
+        {
+            if (tcs == null)
+            {
+                throw new ArgumentNullException("tcs");
+            }
+
+            if (template == null)
+            {
+                throw new ArgumentNullException("template");
+            }
+
+            if (!template.IsCompleted)
+            {
+                throw new ArgumentException("Task must be completed first.", "template");
+            }
+
+            if (template.IsFaulted)
+            {
+                tcs.SetException(template.Exception);
+            }
+            else if (template.IsCanceled)
+            {
+                tcs.SetCanceled();
+            }
+            else
+            {
+                tcs.SetResult(template.Result);
+            }
         }
     }
 }

--- a/STAExamples/Samples.cs
+++ b/STAExamples/Samples.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace STAExamples
@@ -12,16 +13,20 @@ namespace STAExamples
         }
 
         [STAFact]
-        public static void STAFact_OnSTAThread()
+        public static async Task STAFact_OnSTAThread()
         {
             Assert.Equal(ApartmentState.STA, Thread.CurrentThread.GetApartmentState());
+            await Task.Yield();
+            Assert.Equal(ApartmentState.STA, Thread.CurrentThread.GetApartmentState()); // still there
         }
 
         [STATheory]
         [InlineData(0)]
-        public static void STATheory_OnSTAThread(int unused)
+        public static async Task STATheory_OnSTAThread(int unused)
         {
             Assert.Equal(ApartmentState.STA, Thread.CurrentThread.GetApartmentState());
+            await Task.Yield();
+            Assert.Equal(ApartmentState.STA, Thread.CurrentThread.GetApartmentState()); // still there
         }
     }
 }


### PR DESCRIPTION
This fixes the STAFactAttribute sample such that async test methods remain on the STA thread rather than immediately reverting to an MTA thread after a yielding await.
This better emulates the GUI apps that the attribute is useful for testing in the first place.