### PR TITLE
Adding AsyncFlowOption to AutoRollback example

### DIFF
--- a/AutoRollbackExample/AutoRollbackAttribute.cs
+++ b/AutoRollbackExample/AutoRollbackAttribute.cs
@@ -33,6 +33,12 @@ namespace AutoRollbackExample
         public long TimeoutInMS { get; set; } = -1;
 
         /// <summary>
+        /// Gets or sets whether transaction flow across thread continuations is enabled for TransactionScope.
+        /// By default transaction flow across thread continuations is enabled.
+        /// </summary>
+        public TransactionScopeAsyncFlowOption AsyncFlowOption = TransactionScopeAsyncFlowOption.Enabled;
+
+        /// <summary>
         /// Rolls back the transaction.
         /// </summary>
         public override void After(MethodInfo methodUnderTest)
@@ -49,7 +55,7 @@ namespace AutoRollbackExample
             if (TimeoutInMS > 0)
                 options.Timeout = TimeSpan.FromMilliseconds(TimeoutInMS);
 
-            scope = new TransactionScope(ScopeOption, options);
+            scope = new TransactionScope(ScopeOption, options, AsyncFlowOption);
         }
     }
 }

--- a/AutoRollbackExample/AutoRollbackExample.csproj
+++ b/AutoRollbackExample/AutoRollbackExample.csproj
@@ -11,10 +11,11 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>AutoRollbackExample</RootNamespace>
     <AssemblyName>AutoRollbackExample</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
For tests that are marked as async TransactionScopeAsyncFlowOption
needs to be enabled to keep the transaction flowing across thread
continuations. Without it you'll  receive "A TransactionScope must be
disposed on the same thread that it was created" when the async
tests are executed.

One gotcha is this is only available for .NET 4.5.1 projects. Had to
upgrade the project's target framework to enable this.