### PR TITLE
Fixed cached culture-related information bug in UseCultureAttribute

### DIFF
--- a/UseCulture/UseCultureAttribute.cs
+++ b/UseCulture/UseCultureAttribute.cs
@@ -68,6 +68,9 @@ public class UseCultureAttribute : BeforeAfterTestAttribute
 
         Thread.CurrentThread.CurrentCulture = Culture;
         Thread.CurrentThread.CurrentUICulture = UICulture;
+
+        CultureInfo.CurrentCulture.ClearCachedData();
+        CultureInfo.CurrentUICulture.ClearCachedData();
     }
 
     /// <summary>
@@ -79,5 +82,8 @@ public class UseCultureAttribute : BeforeAfterTestAttribute
     {
         Thread.CurrentThread.CurrentCulture = originalCulture;
         Thread.CurrentThread.CurrentUICulture = originalUICulture;
+
+        CultureInfo.CurrentCulture.ClearCachedData();
+        CultureInfo.CurrentUICulture.ClearCachedData();
     }
 }

--- a/UseCulture/UseCultureAttributeTests.cs
+++ b/UseCulture/UseCultureAttributeTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using System.Linq;
 using System.Threading;
 using Xunit;
@@ -109,5 +110,26 @@ public class UseCultureAttributeTests
     public void AttributeChangesUICultureToChileanSpanishInTestMethod()
     {
         Assert.Equal("es-CL", Thread.CurrentThread.CurrentUICulture.Name);
+    }
+
+    [Theory]
+    [InlineData("it-IT")]
+    [InlineData("ja-JP")]
+    [InlineData("nb-NO")]
+    public void RefreshCachedCultureRelatedInformationWithinTest(string culture)
+    {
+        var originalCulture = Thread.CurrentThread.CurrentCulture;
+        var attr = new UseCultureAttribute(culture);
+
+        attr.Before(null);
+
+        var ri = new RegionInfo(Thread.CurrentThread.CurrentCulture.LCID);
+
+        Assert.Equal(attr.Culture, Thread.CurrentThread.CurrentCulture);
+        Assert.Equal(ri.TwoLetterISORegionName, RegionInfo.CurrentRegion.TwoLetterISORegionName);
+
+        attr.After(null);
+
+        Assert.Equal(originalCulture, Thread.CurrentThread.CurrentCulture);
     }
 }


### PR DESCRIPTION
CultureInfo (and it's related classes) will cache information during the life of the AppDomain. Changing the current culture doesn't invalidate the cache. This needs to be done explicit by calling 
[CultureInfo.ClearCacheData](https://msdn.microsoft.com/en-us/library/system.globalization.cultureinfo.clearcacheddata%28v=vs.110%29.aspx)

For example calling [RegionInfo.CurrentRegion](https://msdn.microsoft.com/en-us/library/system.globalization.regioninfo.currentregion%28v=vs.110%29.aspx) will display this behavior. When running for the first time, but on multiple call's the old value is still stored.
