### PR TITLE
CultureInfo ctor should use default culture settings

### DIFF
--- a/UseCulture/UseCultureAttribute.cs
+++ b/UseCulture/UseCultureAttribute.cs
@@ -41,8 +41,8 @@ public class UseCultureAttribute : BeforeAfterTestAttribute
     /// <param name="uiCulture">The name of the UI culture.</param>
     public UseCultureAttribute(string culture, string uiCulture)
     {
-        this.culture = new Lazy<CultureInfo>(() => new CultureInfo(culture));
-        this.uiCulture = new Lazy<CultureInfo>(() => new CultureInfo(uiCulture));
+        this.culture = new Lazy<CultureInfo>(() => new CultureInfo(culture, false));
+        this.uiCulture = new Lazy<CultureInfo>(() => new CultureInfo(uiCulture, false));
     }
 
     /// <summary>


### PR DESCRIPTION
The `CultureInfo` constructor's `useUserOverride` argument defaults to `true` ([source](https://referencesource.microsoft.com/#mscorlib/system/globalization/cultureinfo.cs,325)), which has the unfortunate effect that if you call `new CultureInfo("en-US")` while on an OS that is set to use **user-modified** en-US regional settings, those modifications will get picked up. This leads to code that picks up different settings depending on which computer you run it on. By setting `useUserOverride` to `false` the problem goes away and you'll always get a fresh set of default settings for the requested culture.